### PR TITLE
API: Create tagfield 2.x to support SS4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,29 +5,16 @@ sudo: false
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
 
 env:
-  - DB=MYSQL CORE_RELEASE=3.2
-
-matrix:
-  include:
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2
-  allow_failures:
-    - php: 7.0
+  - DB=MYSQL CORE_RELEASE=master
 
 before_script:
   - composer self-update || true
-  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+  - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
   - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
   - cd ~/builds/ss
   - composer install

--- a/code/StringTagField.php
+++ b/code/StringTagField.php
@@ -1,5 +1,17 @@
 <?php
 
+use SilverStripe\ORM\DataObject;
+use SilverStripe\View\Requirements;
+use SilverStripe\Control\Controller;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\View\ArrayData;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\ORM\DataObjectInterface;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Convert;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\DropdownField;
+
 /**
  * Provides a tagging interface, storing comma-delimited tags in a DataObject string field.
  *
@@ -268,13 +280,13 @@ class StringTagField extends DropdownField
      *
      * @return SS_HTTPResponse
      */
-    public function suggest(SS_HTTPRequest $request)
+    public function suggest(HTTPRequest $request)
     {
         $responseBody = Convert::raw2json(
             array('items' => array())
         );
 
-        $response = new SS_HTTPResponse();
+        $response = new HTTPResponse();
         $response->addHeader('Content-Type', 'application/json');
 
         if ($record = $this->getRecord()) {

--- a/code/TagField.php
+++ b/code/TagField.php
@@ -11,7 +11,7 @@ use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\ReadonlyField;
 
 /**
@@ -20,7 +20,7 @@ use SilverStripe\Forms\ReadonlyField;
  * @package forms
  * @subpackage fields
  */
-class TagField extends DropdownField
+class TagField extends FormField
 {
     /**
      * @var array
@@ -54,6 +54,12 @@ class TagField extends DropdownField
      */
     protected $isMultiple = true;
 
+
+    /**
+     * @var SilverStripe\ORM\SS_List
+     */
+    protected $source = true;
+
     /**
      * @param string $name
      * @param string $title
@@ -62,7 +68,8 @@ class TagField extends DropdownField
      */
     public function __construct($name, $title = '', $source = null, $value = null)
     {
-        parent::__construct($name, $title, $source, $value);
+        parent::__construct($name, $title, $value);
+        $this->source = $source;
     }
 
     /**
@@ -163,6 +170,14 @@ class TagField extends DropdownField
         $this->titleField = $titleField;
 
         return $this;
+    }
+
+    public function getSource() {
+        return $this->source;
+    }
+
+    public function setSource() {
+        return $this->source;
     }
 
     /**

--- a/code/TagField.php
+++ b/code/TagField.php
@@ -1,5 +1,19 @@
 <?php
 
+use SilverStripe\View\Requirements;
+use SilverStripe\Control\Controller;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
+use SilverStripe\View\ArrayData;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\ORM\DataObjectInterface;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\ReadonlyField;
+
 /**
  * Provides a tagging interface, storing links between tag DataObjects and a parent DataObject.
  *
@@ -352,11 +366,11 @@ class TagField extends DropdownField
      *
      * @return SS_HTTPResponse
      */
-    public function suggest(SS_HTTPRequest $request)
+    public function suggest(HTTPRequest $request)
     {
         $tags = $this->getTags($request->getVar('term'));
 
-        $response = new SS_HTTPResponse();
+        $response = new HTTPResponse();
         $response->addHeader('Content-Type', 'application/json');
         $response->setBody(json_encode(array('items' => $tags)));
 

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
 		"issues": "http://github.com/silverstripe-labs/silverstripe-tagfield/issues"
 	},
 	"require": {
-		"silverstripe/framework": "~3.1"
+		"silverstripe/framework": "^4"
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.3.x-dev"
+			"dev-master": "2.x-dev"
 		}
 	}
 }

--- a/tests/StringTagFieldTest.php
+++ b/tests/StringTagFieldTest.php
@@ -1,5 +1,14 @@
 <?php
 
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\Form;
+use SilverStripe\Control\Controller;
+
 /**
  * @mixin PHPUnit_Framework_TestCase
  */
@@ -107,7 +116,7 @@ class StringTagFieldTest extends SapphireTest
      */
     protected function getNewRequest(array $parameters)
     {
-        return new SS_HTTPRequest(
+        return new HTTPRequest(
             'get',
             'StringTagFieldTestController/StringTagFieldTestForm/fields/Tags/suggest',
             $parameters

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -1,5 +1,15 @@
 <?php
 
+use SilverStripe\ORM\DataList;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Control\Controller;
+
 /**
  * @mixin PHPUnit_Framework_TestCase
  */
@@ -255,7 +265,7 @@ class TagFieldTest extends SapphireTest
      */
     protected function getNewRequest(array $parameters)
     {
-        return new SS_HTTPRequest(
+        return new HTTPRequest(
             'get',
             'TagFieldTestController/TagFieldTestForm/fields/Tags/suggest',
             $parameters
@@ -269,7 +279,7 @@ class TagFieldTest extends SapphireTest
 
         $form = new Form(
             new TagFieldTestController($record),
-            'Form',
+            'SilverStripe\\Forms\\Form',
             new FieldList(
                 $field = new TagField('Tags', '', new DataList('TagFieldTestBlogTag'))
             ),


### PR DESCRIPTION
The branch alias has been updated to that the master branch provides
2.x-dev, which requires silverstripe framework ^4.

The auto-updater has been applied to the module.

The travis build has been updated for SS4’s requirements.