### PR TITLE
BUG Fix issue with initial save

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -327,8 +327,7 @@ class TagField extends DropdownField
         if (!$values) {
             $values = array();
         }
-
-        if (empty($record) || empty($source) || empty($titleField)) {
+        if (empty($record) || empty($titleField)) {
             return;
         }
 

--- a/tests/TagFieldTest.php
+++ b/tests/TagFieldTest.php
@@ -313,6 +313,32 @@ class TagFieldTest extends SapphireTest
             $record
         );
     }
+
+    /**
+     * Test you can save without a source set
+     */
+    public function testSaveEmptySource()
+    {
+        $record = new TagFieldTestBlogPost();
+        $record->write();
+
+        // Clear database of tags
+        TagFieldTestBlogTag::get()->removeAll();
+
+        $field = new TagField('Tags', '', TagFieldTestBlogTag::get());
+        $field->setValue(['New Tag']);
+        $field->setCanCreate(true);
+        $field->saveInto($record);
+
+        $tag = TagFieldTestBlogTag::get()->first();
+        $this->assertNotEmpty($tag);
+        $this->assertEquals('New Tag', $tag->Title);
+        $record = TagFieldTestBlogPost::get()->byID($record->ID);
+        $this->assertEquals(
+            $tag->ID,
+            $record->Tags()->first()->ID
+        );
+    }
 }
 
 class TagFieldTestBlogTag extends DataObject implements TestOnly


### PR DESCRIPTION
If the target list is empty, you can't save the first item into it. This fixes this issue.