### PR TITLE
Remove `Requirements::javascript()` for Framework src JS

### DIFF
--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -153,8 +153,6 @@ class StringTagField extends DropdownField
         Requirements::css(TAG_FIELD_DIR . '/css/select2.min.css');
         Requirements::css(TAG_FIELD_DIR . '/css/TagField.css');
 
-        Requirements::javascript(ADMIN_THIRDPARTY_DIR . '/jquery/jquery.js');
-        Requirements::javascript(ADMIN_THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
         Requirements::javascript(TAG_FIELD_DIR . '/js/select2.js');
         Requirements::javascript(TAG_FIELD_DIR . '/js/TagField.js');
 

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -201,8 +201,6 @@ class TagField extends DropdownField
         Requirements::css(TAG_FIELD_DIR . '/css/select2.min.css');
         Requirements::css(TAG_FIELD_DIR . '/css/TagField.css');
 
-        Requirements::javascript(ADMIN_THIRDPARTY_DIR . '/jquery/jquery.js');
-        Requirements::javascript(ADMIN_THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
         Requirements::javascript(TAG_FIELD_DIR . '/js/select2.js');
         Requirements::javascript(TAG_FIELD_DIR . '/js/TagField.js');
 


### PR DESCRIPTION
As jQuery is bundled in the frameworks vendor.js having
  these calls causes a duplicate of the jQuery library

This also means plugins link with the wrong library etc.
  Noticed with `jQuery.dialog()` from a Page edit screen
  going to an associated DataObject edit screen