### PR TITLE
Allow use of setHasEmptyDefault() in StringTagField

### DIFF
--- a/code/StringTagField.php
+++ b/code/StringTagField.php
@@ -161,6 +161,11 @@ class StringTagField extends DropdownField
             $this->setAttribute('multiple', 'multiple');
         }
 
+        if ($this->getHasEmptyDefault()) {
+            $this->setAttribute('data-allow-clear', true);
+            $this->setAttribute('data-placeholder', $this->getEmptyString() ?: ' ');
+        }
+
         if ($this->getShouldLazyLoad()) {
             $this->setAttribute('data-ss-tag-field-suggest-url', $this->getSuggestURL());
         } else {
@@ -198,6 +203,14 @@ class StringTagField extends DropdownField
         }
 
         $values = $this->Value();
+
+        if ($this->getHasEmptyDefault()) {
+            $options->push(ArrayData::create(array(
+                'Value' => '',
+                'Title' => '',
+                'Selected' => empty($values)
+            )));
+        }
 
         foreach ($source as $value) {
             $options->push(


### PR DESCRIPTION
If using `StringTagField::setMultiple(false)`, it’s currently impossible to have an empty default, and therefore impossible to unset a value. This change:

- Adds in a blank `<option></option>` if `setHasEmptyDefault(true)` has been called
- Allows users to clear the current selection (`data-allow-clear` adds the little cross)
- Adds a placeholder attribute. Select2 uses `data-placeholder` as `placeholder` isn’t valid on a `<select>`. Also, an empty (or `''`) placeholder doesn’t work, so it’s subbing in a space for that