### PR TITLE
Resolve TagField performance for lazyload

### DIFF
--- a/src/TagField.php
+++ b/src/TagField.php
@@ -71,7 +71,7 @@ class TagField extends DropdownField
     {
         $this->setSourceList($source);
         $this->setTitleField($titleField);
-        parent::__construct($name, $title, $source, $value);
+        parent::__construct($name, $title, [], $value);
     }
 
     /**

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -262,6 +262,20 @@ class TagField extends DropdownField
         $ids = $values->column($this->getTitleField());
 
         $titleField = $this->getTitleField();
+        
+        if ($this->shouldLazyLoad) {
+            // only render options that are selected as everything else should be lazy loaded, and or loaded by the form
+            foreach ($values as $value) {
+                $options->push(
+                    ArrayData::create(array(
+                        'Title' => $value->$titleField,
+                        'Value' => $value->Title,
+                        'Selected' => true, // only values are iterated.
+                    ))
+                );
+            }
+            return $options;
+        }
 
         foreach ($source as $object) {
             $options->push(

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -313,6 +313,21 @@ class TagField extends DropdownField
     }
 
     /**
+     * Gets the source array if required
+     *
+     * Note: this is expensive for a SS_List
+     *
+     * @return array
+     */
+    public function getSource()
+    {
+        if (is_null($this->source)) {
+            $this->setSource($this->getSourceList());
+        }
+        return $this->source;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getAttributes()


### PR DESCRIPTION
As a descendent of SelectField when source is passed to the parent, `getListMap()` hydrates any objects in the list. For a ManyMany or a HasMany relationship that can be extremely costly, as these could contain 1000's of elements. 

Instead we pass an empty array, and hydrate it on demand if requested. If the TagField uses lazy load, we don't need to hydrate the RelationList for all possible options as these can be loaded via XHR and better limited later. Instead, we only render the values and the options for those values into the component itself, and everything else can be done via separate requests.

@see #115 