### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/StringTagField.php
+++ b/src/StringTagField.php
@@ -270,7 +270,7 @@ class StringTagField extends DropdownField
      */
     public function suggest(HTTPRequest $request)
     {
-        $responseBody = Convert::raw2json(
+        $responseBody = json_encode(
             array('items' => array())
         );
 
@@ -285,7 +285,7 @@ class StringTagField extends DropdownField
                 $tags = $this->getTags($term);
             }
 
-            $responseBody = Convert::raw2json(
+            $responseBody = json_encode(
                 array('items' => $tags)
             );
         }

--- a/src/TagField.php
+++ b/src/TagField.php
@@ -219,7 +219,7 @@ class TagField extends DropdownField
             }
             $schema['optionUrl'] = $this->getSuggestURL();
         }
-        $this->setAttribute('data-schema', Convert::array2json($schema));
+        $this->setAttribute('data-schema', json_encode($schema));
 
         $this->addExtraClass('ss-tag-field');
 


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424